### PR TITLE
I51 Fix: Navbar indicator bugs out when page is refreshed

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useRouter } from 'next/router'
 import {
   ChatAltIcon,
   ExclamationCircleIcon,
@@ -10,7 +11,15 @@ import { NavIcon } from '@/components/NavBar/navicon'
 import NavLink from '@/components/NavBar/navlink'
 
 export default function NavBar() {
-  const [currentPage, setCurrentPage] = useState('Home')
+  // Gets top level path, capitalises first letter
+  const { asPath } = useRouter()
+  const pathStart = asPath.split('/')[1]
+  const currentPageTitle =
+    pathStart === ''
+      ? 'Home'
+      : `${pathStart.charAt(0).toUpperCase()}${pathStart.slice(1)}`
+
+  const [currentPage, setCurrentPage] = useState(currentPageTitle)
   const iconClasses = 'inline-block h-7 w-8 hover:text-poops-red'
 
   const linkDetails = [

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -17,7 +17,9 @@ export default function NavBar() {
   const currentPageTitle =
     pathStart === ''
       ? 'Home'
-      : `${pathStart.charAt(0).toUpperCase()}${pathStart.slice(1)}`
+      : `${pathStart.charAt(0).toUpperCase()}${pathStart
+          .slice(1)
+          .toLowerCase()}`
 
   const [currentPage, setCurrentPage] = useState(currentPageTitle)
   const iconClasses = 'inline-block h-7 w-8 hover:text-poops-red'

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -24,7 +24,6 @@ export default function NavBar() {
   const [currentPage, setCurrentPage] = useState(currentPageTitle)
   const iconClasses = 'inline-block h-7 w-8 hover:text-primary'
 
-
   const linkDetails = [
     { name: 'Home', route: '/', icon: <HomeIcon className={iconClasses} /> },
     {


### PR DESCRIPTION
## Change Summary
Navbar now bases its initial indicator value based on the page being loaded rather than defaulting to home. 

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
N/A

# Related Issue

- Resolve #51