### PR TITLE
i84 - Replaced grey w/ colors.gray

### DIFF
--- a/src/components/Contact/contactform.tsx
+++ b/src/components/Contact/contactform.tsx
@@ -96,7 +96,7 @@ const ContactForm = ({ contact, image, setIsEditing }: ContactInfoProps) => {
           <input
             name='first_name'
             defaultValue={contact.firstName}
-            className='mb-2 w-80 rounded-lg border border-grey pl-1'
+            className='mb-2 w-80 rounded-lg border border-gray-300 pl-1'
             onChange={handleInputChange}
           />
         </Box>
@@ -107,7 +107,7 @@ const ContactForm = ({ contact, image, setIsEditing }: ContactInfoProps) => {
           <input
             name='last_name'
             defaultValue={contact.lastName}
-            className='mb-2 w-80 rounded-lg border border-grey pl-1'
+            className='mb-2 w-80 rounded-lg border border-gray-300 pl-1'
             onChange={handleInputChange}
           />
         </Box>
@@ -119,7 +119,7 @@ const ContactForm = ({ contact, image, setIsEditing }: ContactInfoProps) => {
           <textarea
             name='desc'
             defaultValue={contact.desc}
-            className='w-80 rounded-lg border border-grey pl-1'
+            className='w-80 rounded-lg border border-gray-300 pl-1'
             onChange={handleInputChange}
           />
         </Box>
@@ -131,7 +131,7 @@ const ContactForm = ({ contact, image, setIsEditing }: ContactInfoProps) => {
           <input
             name='phone'
             defaultValue={contact.phone}
-            className='mb-2 w-full rounded-lg border border-grey pl-1'
+            className='mb-2 w-full rounded-lg border border-gray-300 pl-1'
             onChange={handleInputChange}
           />
         </Box>
@@ -143,7 +143,7 @@ const ContactForm = ({ contact, image, setIsEditing }: ContactInfoProps) => {
           <input
             name='email'
             defaultValue={contact.email}
-            className='mb-2 w-full rounded-lg border border-grey pl-1'
+            className='mb-2 w-full rounded-lg border border-gray-300 pl-1'
             onChange={handleInputChange}
           />
         </Box>
@@ -155,7 +155,7 @@ const ContactForm = ({ contact, image, setIsEditing }: ContactInfoProps) => {
           <input
             name='street_address'
             defaultValue={contact.streetAddress}
-            className='mb-2 w-full rounded-lg border border-grey pl-1'
+            className='mb-2 w-full rounded-lg border border-gray-300 pl-1'
             onChange={handleInputChange}
           />
         </Box>
@@ -196,7 +196,7 @@ const ContactForm = ({ contact, image, setIsEditing }: ContactInfoProps) => {
                 <input
                   name='name'
                   defaultValue={pet.name}
-                  className='mb-2 w-full rounded-lg border border-grey pl-1'
+                  className='mb-2 w-full rounded-lg border border-gray-300 pl-1'
                   onChange={(e) => handlePetChange(i, e)}
                 />
 
@@ -206,7 +206,7 @@ const ContactForm = ({ contact, image, setIsEditing }: ContactInfoProps) => {
                 <textarea
                   name='notes'
                   defaultValue={pet.notes}
-                  className='mb-2 w-full rounded-lg border border-grey pl-1'
+                  className='mb-2 w-full rounded-lg border border-gray-300 pl-1'
                   onChange={(e) => handlePetChange(i, e)}
                 />
               </PetContainer>
@@ -227,7 +227,7 @@ const ContactForm = ({ contact, image, setIsEditing }: ContactInfoProps) => {
           <textarea
             name='notes'
             defaultValue={contact.notes}
-            className='w-full rounded-lg border border-grey'
+            className='w-full rounded-lg border border-gray-300'
             onChange={handleInputChange}
           />
         </Box>
@@ -242,7 +242,7 @@ const ContactForm = ({ contact, image, setIsEditing }: ContactInfoProps) => {
             </button>
             <button
               type='button'
-              className='w-80 rounded bg-grey py-1 font-bold text-black hover:bg-grey'
+              className='w-80 rounded bg-gray-300 py-1 font-bold text-black hover:bg-gray-300'
               onClick={() => setIsEditing(false)}
             >
               Cancel
@@ -257,7 +257,7 @@ const ContactForm = ({ contact, image, setIsEditing }: ContactInfoProps) => {
 export default ContactForm
 
 const Box = tw.div`
-    bg-grey
+    bg-gray-300
     bg-opacity-20
     box-content
     w-80

--- a/src/components/Contact/contactinfo.tsx
+++ b/src/components/Contact/contactinfo.tsx
@@ -127,7 +127,7 @@ function ContactInfo({ contact, image }: ContactInfoProps) {
 export default ContactInfo
 
 const Box = tw.div`
-    bg-grey
+    bg-gray-300
     bg-opacity-20
     box-content
     w-80

--- a/src/components/Contact/contactitem.tsx
+++ b/src/components/Contact/contactitem.tsx
@@ -14,7 +14,7 @@ const ContactItem = ({ contact, image }: ContactItemProps) => {
     .join(', ')
 
   return (
-    <li className='hover:bg-grey focus:bg-grey flex items-center justify-between truncate border-b border-gray-300 bg-white p-3 px-5 text-sm text-gray-900 sm:py-4'>
+    <li className='flex items-center justify-between truncate border-b border-gray-300 bg-white p-3 px-5 text-sm text-gray-900 hover:bg-gray-300 focus:bg-gray-300 sm:py-4'>
       {/* USER PROFILE IMAGE */}
       <span className='flex items-center space-x-4'>
         <Avatar image={image} height={40} width={40} iconClass='h-10 w-10' />

--- a/src/components/Contact/contactitem.tsx
+++ b/src/components/Contact/contactitem.tsx
@@ -7,17 +7,22 @@ type ContactItemProps = {
 }
 
 const ContactItem = ({ contact, image }: ContactItemProps) => {
+  const petNames = contact.pets
+    .map((pet) => {
+      return pet.name
+    })
+    .join(', ')
+
   return (
-    <li className='border-b border-grey bg-white p-3 px-5 hover:bg-grey focus:bg-grey sm:py-4'>
-      <div className='flex items-center space-x-4'>
-        {/* USER PROFILE IMAGE */}
+    <li className='hover:bg-grey focus:bg-grey flex items-center justify-between truncate border-b border-gray-300 bg-white p-3 px-5 text-sm text-gray-900 sm:py-4'>
+      {/* USER PROFILE IMAGE */}
+      <span className='flex items-center space-x-4'>
         <Avatar image={image} height={40} width={40} iconClass='h-10 w-10' />
-        <div className='min-w-0 flex-1'>
-          <p className='text-gray-900 truncate text-sm font-medium'>
-            {`${contact.firstName} ${contact.lastName}`}
-          </p>
-        </div>
-      </div>
+        <p className='font-medium text-gray-700'>
+          {`${contact.firstName} ${contact.lastName}`}
+        </p>
+      </span>
+      <p className=''>{petNames}</p>
     </li>
   )
 }

--- a/src/components/Contact/contactitem.tsx
+++ b/src/components/Contact/contactitem.tsx
@@ -7,22 +7,17 @@ type ContactItemProps = {
 }
 
 const ContactItem = ({ contact, image }: ContactItemProps) => {
-  const petNames = contact.pets
-    .map((pet) => {
-      return pet.name
-    })
-    .join(', ')
-
   return (
-    <li className='flex items-center justify-between truncate border-b border-gray-300 bg-white p-3 px-5 text-sm text-gray-900 hover:bg-gray-300 focus:bg-gray-300 sm:py-4'>
-      {/* USER PROFILE IMAGE */}
-      <span className='flex items-center space-x-4'>
+    <li className='border-b border-gray-300 bg-white p-3 px-5 hover:bg-gray-300 focus:bg-gray-300 sm:py-4'>
+      <div className='flex items-center space-x-4'>
+        {/* USER PROFILE IMAGE */}
         <Avatar image={image} height={40} width={40} iconClass='h-10 w-10' />
-        <p className='font-medium text-gray-700'>
-          {`${contact.firstName} ${contact.lastName}`}
-        </p>
-      </span>
-      <p className=''>{petNames}</p>
+        <div className='min-w-0 flex-1'>
+          <p className='truncate text-sm font-medium text-gray-900'>
+            {`${contact.firstName} ${contact.lastName}`}
+          </p>
+        </div>
+      </div>
     </li>
   )
 }

--- a/src/components/Contact/profileitem.tsx
+++ b/src/components/Contact/profileitem.tsx
@@ -14,7 +14,7 @@ const ProfileItem = ({ profile, image }: ProfileItemProps) => {
       <a>
         <div className='mt-1 flex-col'>
           <ul>
-            <li className='border-b border-grey bg-white p-3 px-5 hover:bg-grey focus:bg-grey sm:py-4'>
+            <li className='hover:bg-grey focus:bg-grey border-b border-gray-300 bg-white p-3 px-5 sm:py-4'>
               <div className='flex items-center space-x-4'>
                 {/* USER PROFILE IMAGE */}
                 <Avatar
@@ -24,7 +24,7 @@ const ProfileItem = ({ profile, image }: ProfileItemProps) => {
                   iconClass='h-16 w-16'
                 />
                 <div className='min-w-0 flex-1'>
-                  <p className='text-gray-900 truncate text-sm font-medium'>
+                  <p className='truncate text-sm font-medium text-gray-900'>
                     Me
                   </p>
                 </div>

--- a/src/components/Login/LoginButton.tsx
+++ b/src/components/Login/LoginButton.tsx
@@ -16,7 +16,7 @@ const LoginButton = (props: LoginButtonInterface) => {
     <button className={props.style} onClick={props.handler}>
       <div className='relative flex items-center space-x-4'>
         <div className='w-5'>{props.icon}</div>
-        <span className='text-gray-700 block w-max text-sm font-semibold tracking-wide transition duration-300 sm:text-base'>
+        <span className='block w-max text-sm font-semibold tracking-wide text-gray-700 transition duration-300 sm:text-base'>
           {props.buttonlabel}
         </span>
       </div>

--- a/src/pages/contact/index.tsx
+++ b/src/pages/contact/index.tsx
@@ -66,7 +66,7 @@ const Contact = () => {
         </div>
 
         <div className='m-auto max-w-md'>
-          <div className='m-2 flex flex-row rounded-xl border-2 border-grey'>
+          <div className='m-2 flex flex-row rounded-xl border-2 border-gray-300'>
             <SearchTag options={taglist} onChangehandler={onSearchTagChange} />
             <div className='flex w-full justify-between'>
               <SearchBar onChangeHandler={onSearchChange} />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,7 +14,7 @@ module.exports = {
       'dark-red': '#a52a2a',
       transparent: 'transparent',
       current: 'currentColor',
-      grey: '#C5C5C5',
+      gray: colors.gray,
       white: '#ffffff',
       black: '#000000',
       facebook: '#4267B2',


### PR DESCRIPTION
Import the Tailwind default gray variants and replace existing use of grey. Using the [documentation](https://tailwindcss.com/docs/customizing-colors#using-the-default-colors).

This means we have access to several variants of grey, i.e. `text-gray-500` or `bg-gray-700`.

- [ x] The pull request title has an issue number
- [ x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

# Related Issue

- Resolve #84