### PR TITLE
i72 - Added petnames to contact list

### DIFF
--- a/src/components/Contact/contactitem.tsx
+++ b/src/components/Contact/contactitem.tsx
@@ -7,22 +7,17 @@ type ContactItemProps = {
 }
 
 const ContactItem = ({ contact, image }: ContactItemProps) => {
-  const petNames = contact.pets
-    .map((pet) => {
-      return pet.name
-    })
-    .join(', ')
-
   return (
-    <li className='flex items-center justify-between truncate border-b border-gray-300 bg-white p-3 px-5 text-sm text-gray-900 hover:bg-gray-300 focus:bg-gray-300 sm:py-4'>
-      {/* USER PROFILE IMAGE */}
-      <span className='flex items-center space-x-4'>
+    <li className='border-b border-gray-300 bg-white p-3 px-5 hover:bg-gray-300 focus:bg-gray-300 sm:py-4'>
+      <div className='flex items-center space-x-4'>
+        {/* USER PROFILE IMAGE */}
         <Avatar image={image} height={40} width={40} iconClass='h-10 w-10' />
-        <p className='font-medium text-gray-700'>
-          {`${contact.firstName} ${contact.lastName}`}
-        </p>
-      </span>
-      <p className=''>{petNames}</p>
+        <div className='min-w-0 flex-1'>
+          <p className='truncate text-sm font-medium text-gray-900'>
+            {`${contact.firstName} ${contact.lastName}`}
+          </p>
+        </div>
+      </div>
     </li>
   )
 }

--- a/src/components/Contact/contactitem.tsx
+++ b/src/components/Contact/contactitem.tsx
@@ -1,5 +1,6 @@
 import Avatar from '@/components/Contact/avatar'
 import type { Contact } from '@/types/types'
+import truncateText from '@/utils/truncateText'
 
 type ContactItemProps = {
   contact: Contact
@@ -7,17 +8,22 @@ type ContactItemProps = {
 }
 
 const ContactItem = ({ contact, image }: ContactItemProps) => {
+  const petNames = contact.pets
+    .map((pet) => {
+      return pet.name
+    })
+    .join(', ')
+
   return (
-    <li className='border-b border-gray-300 bg-white p-3 px-5 hover:bg-gray-300 focus:bg-gray-300 sm:py-4'>
-      <div className='flex items-center space-x-4'>
-        {/* USER PROFILE IMAGE */}
+    <li className='hover:bg-grey focus:bg-grey flex items-center justify-between truncate border-b border-gray-300 bg-white p-3 px-5 text-sm sm:py-4'>
+      {/* USER PROFILE IMAGE */}
+      <span className='flex items-center space-x-4'>
         <Avatar image={image} height={40} width={40} iconClass='h-10 w-10' />
-        <div className='min-w-0 flex-1'>
-          <p className='truncate text-sm font-medium text-gray-900'>
-            {`${contact.firstName} ${contact.lastName}`}
-          </p>
-        </div>
-      </div>
+        <p className='font-medium text-gray-700'>
+          {truncateText(`${contact.firstName} ${contact.lastName}`, 24)}
+        </p>
+      </span>
+      <p className='text-gray-500'>{truncateText(petNames, 16)}</p>
     </li>
   )
 }

--- a/src/components/Contact/contactitem.tsx
+++ b/src/components/Contact/contactitem.tsx
@@ -15,7 +15,7 @@ const ContactItem = ({ contact, image }: ContactItemProps) => {
     .join(', ')
 
   return (
-    <li className='hover:bg-grey focus:bg-grey flex items-center justify-between truncate border-b border-gray-300 bg-white p-3 px-5 text-sm sm:py-4'>
+    <li className='flex items-center justify-between truncate border-b border-gray-300 bg-white p-3 px-5 text-sm hover:bg-gray-300 focus:bg-gray-300 sm:py-4'>
       {/* USER PROFILE IMAGE */}
       <span className='flex items-center space-x-4'>
         <Avatar image={image} height={40} width={40} iconClass='h-10 w-10' />

--- a/src/components/Contact/contactlist.tsx
+++ b/src/components/Contact/contactlist.tsx
@@ -19,7 +19,7 @@ const ContactList = ({ contacts }: ContactsProp) => {
   })
 
   return (
-    <div className='mt-1 flex-col'>
+    <div className='flex-col'>
       <ul>{contactItems}</ul>
     </div>
   )

--- a/src/components/Contact/profileitem.tsx
+++ b/src/components/Contact/profileitem.tsx
@@ -14,7 +14,7 @@ const ProfileItem = ({ profile, image }: ProfileItemProps) => {
       <a>
         <div className='mt-1 flex-col'>
           <ul>
-            <li className='hover:bg-grey focus:bg-grey border-b border-gray-300 bg-white p-3 px-5 sm:py-4'>
+            <li className='border-b border-gray-300 bg-white p-3 px-5 hover:bg-gray-300 focus:bg-gray-300 sm:py-4'>
               <div className='flex items-center space-x-4'>
                 {/* USER PROFILE IMAGE */}
                 <Avatar

--- a/src/utils/truncateText.ts
+++ b/src/utils/truncateText.ts
@@ -1,0 +1,15 @@
+/**
+ * Truncates a string to some provided length (defaults to 16 chars) and returns the shortened string
+ *
+ * @param str input string
+ * @param len maximum length of the returned string
+ */
+const truncateText = (str: string, len = 16) => {
+  if (str.length > len) {
+    return str.substring(0, len - 3).concat('...')
+  }
+
+  return str
+}
+
+export default truncateText


### PR DESCRIPTION
# Changes

- Contact list has contact's pets displayed to the right of their name
- There's a new util function called `truncateText` that can be used throughout the app
- When a contact has an extremely long name, or a long list of pets, the strings are truncated to an acceptable length


# Checklist
- [x]  The pull request title has an issue number
- [x]  The change works by "Smoke testing" or quick testing ( I tested what happens when there's no pets, a ridiculous amount of pets, a really long owner name, etc.)
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
Found two instances of the old `grey` colour

# Related Issue

- Resolve #72