### PR TITLE
i108 Standardise commute method for visit page

### DIFF
--- a/src/components/Visit/commuteselector.tsx
+++ b/src/components/Visit/commuteselector.tsx
@@ -16,7 +16,7 @@ interface CommuteSelectorProps extends FormFieldProps {
 
 const addToLocalStorage = (value: string) => {
   let vals = localStorage.getItem('commuteMethods')?.split(',')
-  if (vals === undefined) vals = ['Bus', 'Car', 'Train']
+  if (vals === undefined) vals = ['Drive', 'Walk', 'Public Transport', 'Other']
   if (!vals.includes(value)) {
     vals.push(value)
     vals.sort()
@@ -26,7 +26,8 @@ const addToLocalStorage = (value: string) => {
 
 const getLocalStorage = () => {
   let store = localStorage.getItem('commuteMethods')?.split(',')
-  if (store === undefined) store = ['Bus', 'Car', 'Train']
+  if (store === undefined)
+    store = ['Drive', 'Walk', 'Public Transport', 'Other']
   return store
 }
 


### PR DESCRIPTION
## Change Summary
Changed the commute methods on visit page from 'bus', 'car', 'train' to 'drive', 'walk', 'public transport', 'other'.

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

# Related Issue

- Resolve #108