### PR TITLE
i63 - Created reusable button with variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@heroicons/react": "^1.0.6",
     "babel-plugin-macros": "^3.1.0",
+    "class-variance-authority": "^0.3.0",
     "clsx": "^1.1.1",
     "firebase": "^9.9.0",
     "next": "^12.2.4",

--- a/src/components/Contact/contactdetails.tsx
+++ b/src/components/Contact/contactdetails.tsx
@@ -5,6 +5,7 @@ import ContactForm from '@/components/Contact/contactform'
 import ContactInfo from '@/components/Contact/contactinfo'
 import Header from '@/components/Header'
 import { useContact } from '@/context/ContactContext/context'
+import Button from '../UI/button'
 
 type ContactProp = {
   firestoreIndex: number
@@ -28,16 +29,16 @@ const ContactDetails = ({ firestoreIndex }: ContactProp) => {
       />
       <div className='m-auto flex h-14 max-w-md flex-row'>
         <div className='m-auto flex-1 text-center'>
-          <button
+          <Button
             type='button'
-            className='rounded bg-primary py-1 px-4 font-bold text-white hover:bg-dark-red'
+            size='medium'
             onClick={() => {
               setCreatingNewContact(false)
               setDisplayContactIndex(-1)
             }}
           >
             Back
-          </button>
+          </Button>
         </div>
         <div className='flex-1'></div>
         <div className='m-auto flex-1'>

--- a/src/components/Contact/contactform.tsx
+++ b/src/components/Contact/contactform.tsx
@@ -7,6 +7,7 @@ import RegionSelector from '@/components/Contact/regiondropdown'
 import TagSelector from '@/components/Contact/tagdropdown'
 import { useContact } from '@/context/ContactContext/context'
 import type { Contact } from '@/types/types'
+import Button from '../UI/button'
 
 type ContactInfoProps = {
   firestoreIndex: number
@@ -183,23 +184,20 @@ const ContactForm = ({
         </Box>
         {/* FORM BUTTONS */}
         <div className='mb-3 flex justify-center'>
-          <div className='flex flex-col space-y-1'>
-            <button
-              type='submit'
-              className='w-80 rounded bg-primary py-1 font-bold text-white hover:bg-dark-red'
-            >
+          <div className='space-y-2'>
+            <Button type='submit' fullwidth>
               Save
-            </button>
+            </Button>
             {!isNewContact && (
-              <button
-                type='button'
-                className='bg-grey hover:bg-grey w-80 rounded py-1 font-bold text-black'
+              <Button
+                intent='secondary'
+                fullwidth
                 onClick={() => {
                   if (setIsEditing !== undefined) setIsEditing(false)
                 }}
               >
                 Cancel
-              </button>
+              </Button>
             )}
           </div>
         </div>

--- a/src/components/Contact/contactinfo.tsx
+++ b/src/components/Contact/contactinfo.tsx
@@ -8,6 +8,7 @@ import tw from 'tailwind-styled-components'
 import Avatar from '@/components/Contact/avatar'
 import { AlertVariant, useAlert } from '@/context/AlertContext'
 import { useContact } from '@/context/ContactContext/context'
+import Button from '../UI/button'
 
 type ContactInfoProps = {
   firestoreIndex: number
@@ -124,7 +125,7 @@ function ContactInfo({ firestoreIndex, image }: ContactInfoProps) {
       <div className='mb-2'>
         {/* can't delete users profile */}
         {firestoreIndex !== 0 && (
-          <button
+          <Button
             type='button'
             onClick={() => {
               setAlert({
@@ -139,10 +140,9 @@ function ContactInfo({ firestoreIndex, image }: ContactInfoProps) {
                 }
               })
             }}
-            className='w-80 rounded bg-primary py-1 font-bold text-white hover:bg-dark-red'
           >
             Delete Contact
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/src/components/Home/modal.tsx
+++ b/src/components/Home/modal.tsx
@@ -10,6 +10,7 @@ import FormField from '@/components/Visit/formfield'
 import { visitSelectOptions } from '@/components/Visit/visitlist'
 import { AlertVariant, useAlert } from '@/context/AlertContext'
 import { Duration } from '@/types/types'
+import Button from '../UI/button'
 
 function Modal() {
   const [commute, setCommute] = useState('')
@@ -161,13 +162,14 @@ function Modal() {
             }
           />
 
-          <button
+          <Button
+            className='mt-4 mb-2'
+            size='medium'
             type='submit'
-            className='relative mt-4 mb-2 h-[30px] w-[120px] rounded-lg bg-dark-red text-lg font-semibold text-white disabled:bg-dark-gray'
             disabled={!formFilled()}
           >
-            SUBMIT
-          </button>
+            Submit
+          </Button>
         </form>
       </div>
     </div>

--- a/src/components/UI/button.tsx
+++ b/src/components/UI/button.tsx
@@ -1,0 +1,51 @@
+import { cva, VariantProps } from 'class-variance-authority'
+
+const variants = cva(['rounded-lg', 'font-semibold', 'drop-shadow-default'], {
+  variants: {
+    intent: {
+      primary: [
+        'bg-primary',
+        'text-white',
+        'active:bg-dark-red',
+        'hover:bg-dark-red',
+        'disabled:bg-dark-gray'
+      ],
+      secondary: [
+        'bg-white',
+        'text-gray-800',
+        'border-gray-400',
+        'hover:bg-gray-100'
+      ]
+    },
+    size: {
+      small: ['text-sm', 'py-1', 'px-2'],
+      medium: ['text-base', 'py-2', 'px-4'],
+      large: ['text-lg', 'py-4', 'px-8']
+    },
+    fullwidth: {
+      true: 'w-full'
+    }
+  },
+  defaultVariants: {
+    intent: 'primary',
+    size: 'large'
+  }
+})
+
+type ButtonProps = VariantProps<typeof variants> &
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+
+const Button = ({
+  className,
+  intent,
+  fullwidth,
+  size,
+  ...props
+}: ButtonProps) => (
+  <button
+    className={variants({ className, fullwidth, intent, size })}
+    {...props}
+  />
+)
+
+export default Button

--- a/src/components/Visit/buttons.tsx
+++ b/src/components/Visit/buttons.tsx
@@ -37,23 +37,3 @@ export const AddButton = ({ toggleModal }: AddButtonProps) => {
     </div>
   )
 }
-
-export const VetConcernButton = () => {
-  return (
-    <div className='align-center flex flex-row justify-center rounded-md bg-primary p-2 text-center text-xs font-bold text-white drop-shadow-default'>
-      <button>
-        REGISTER <br /> VET CONCERN
-      </button>
-    </div>
-  )
-}
-
-export const ReportButton = () => {
-  return (
-    <div className='align-center flex flex-row justify-center rounded-md bg-primary p-2 text-center text-xs font-bold text-white drop-shadow-default'>
-      <button>
-        REPORT <br /> INCIDENT
-      </button>
-    </div>
-  )
-}

--- a/src/components/Visit/editvisitinstance.tsx
+++ b/src/components/Visit/editvisitinstance.tsx
@@ -10,6 +10,7 @@ import { useFirestore } from '@/context/Firebase/Firestore/context'
 import { VisitData } from '@/types/types'
 
 import { visitSelectOptions } from './visitlist'
+import Button from '../UI/button'
 
 interface EditVisitInstanceProps extends VisitInstanceProps {
   isEditable: Dispatch<SetStateAction<boolean>>
@@ -190,24 +191,22 @@ const EditableVisitInstance = (props: EditVisitInstanceProps) => {
         </div>
       </div>
 
-      <button
-        type='submit'
-        className='text-bold mt-2 rounded-xl bg-primary p-2 text-white drop-shadow-default active:bg-dark-red'
-      >
-        Submit
-      </button>
-      <button
-        type='button'
-        className='text-bold mt-2 ml-4 rounded-xl bg-primary p-1 text-white drop-shadow-default active:bg-dark-red'
-        onClick={() => {
-          userDoc.visits.splice(props.id, 1)
-          const temp: VisitData[] = [...userDoc.visits] //temp needed for react to rerender
-          props.set(temp)
-          updateVisit?.(userDoc)
-        }}
-      >
-        Remove
-      </button>
+      <div className='flex justify-center gap-2'>
+        <Button size='medium' type='submit'>
+          Submit
+        </Button>
+        <Button
+          size='medium'
+          onClick={() => {
+            userDoc.visits.splice(props.id, 1)
+            const temp: VisitData[] = [...userDoc.visits] //temp needed for react to rerender
+            props.set(temp)
+            updateVisit?.(userDoc)
+          }}
+        >
+          Remove
+        </Button>
+      </div>
     </form>
   )
 }

--- a/src/components/Visit/modal.tsx
+++ b/src/components/Visit/modal.tsx
@@ -8,6 +8,7 @@ import { VisitData } from '@/types/types'
 
 import CommuteSelector from './commuteselector'
 import FormField from './formfield'
+import Button from '../UI/button'
 
 interface ModalViewProps {
   toggleModal: () => void
@@ -169,13 +170,9 @@ const ModalView = ({ toggleModal }: ModalViewProps) => {
             onChange={(event) => setNotes(event.target.value)}
           />
           <div className='mx-auto my-2 flex flex-col p-1 '>
-            <button
-              className='text-bold rounded bg-primary px-12 py-4 text-white drop-shadow-default active:bg-dark-red disabled:bg-dark-gray'
-              disabled={!isSubmitEnabled()}
-              type='submit'
-            >
+            <Button type='submit' disabled={!isSubmitEnabled()}>
               Submit
-            </button>
+            </Button>
           </div>
         </form>
       </>

--- a/src/components/Visit/readvisitinstance.tsx
+++ b/src/components/Visit/readvisitinstance.tsx
@@ -3,6 +3,7 @@ import { Timestamp } from 'firebase/firestore'
 import { ReportButton, VetConcernButton } from '@/components/Visit/buttons'
 import { formatDuration } from '@/components/Visit/visitinstance'
 import { VisitData } from '@/types/types'
+import Button from '../UI/button'
 
 const formatTime = (time: Timestamp) => {
   return time.toDate().toLocaleString().slice(0, -3)
@@ -24,12 +25,9 @@ const ReadOnlyVisitInstance = (props: VisitData) => {
         <p>Commute Distance: {props.commuteDist.toFixed(1)} km</p>
         <p>Commute Method: {props.commuteMethod}</p>
         <p>Notes: {props.notes}</p>
-        <div className='m-2 flex flex-row justify-around'>
-          {
-            // TODO: make stylings nice (gl James)
-          }
-          <VetConcernButton />
-          <ReportButton />
+        <div className='my-2 flex justify-center gap-2'>
+          <Button size='medium'>Register vet concern </Button>
+          <Button size='medium'>Report incident</Button>
         </div>
       </div>
     </>

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -11,6 +11,7 @@ import SearchTag from '@/components/SearchBar/searchtag'
 import TopNav from '@/components/TopNav'
 import { useContact } from '@/context/ContactContext/context'
 import type { Contact } from '@/types/types'
+import Button from '@/components/UI/button'
 
 const Contact = () => {
   const {
@@ -45,13 +46,7 @@ const Contact = () => {
             <div className='flex-1'></div>
             <h1 className='m-3 flex-1 text-center text-2xl'>Contacts</h1>
             <div className='m-auto flex-1 text-center'>
-              <button
-                onClick={() => setCreatingNewContact(true)}
-                type='button'
-                className='rounded bg-primary py-1 px-4 font-bold text-white hover:bg-dark-red'
-              >
-                Add
-              </button>
+              <Button onClick={() => setCreatingNewContact(true)}>Add</Button>
             </div>
           </div>
         )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2914,6 +2914,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+class-variance-authority@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/class-variance-authority/-/class-variance-authority-0.3.0.tgz#40c824bfbe5c604ecb3e337a2353b4b86278888e"
+  integrity sha512-TFO+pzY9Gedqv8crPhprd647wxhvfpKevPPjiMcteEWsnkHX9yZrD1xMY3ZhRZnLwHUHCCP0LYO6KZIVag/5wQ==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -3924,17 +3929,17 @@ firebase@^9.9.0:
   dependencies:
     "@firebase/analytics" "0.8.0"
     "@firebase/analytics-compat" "0.1.13"
-    "@firebase/app" "0.7.29"
-    "@firebase/app-check" "0.5.12"
-    "@firebase/app-check-compat" "0.2.12"
-    "@firebase/app-compat" "0.1.30"
+    "@firebase/app" "0.7.28"
+    "@firebase/app-check" "0.5.11"
+    "@firebase/app-check-compat" "0.2.11"
+    "@firebase/app-compat" "0.1.29"
     "@firebase/app-types" "0.7.0"
     "@firebase/auth" "0.20.5"
     "@firebase/auth-compat" "0.2.18"
     "@firebase/database" "0.13.3"
     "@firebase/database-compat" "0.2.3"
-    "@firebase/firestore" "3.4.13"
-    "@firebase/firestore-compat" "0.1.22"
+    "@firebase/firestore" "3.4.12"
+    "@firebase/firestore-compat" "0.1.21"
     "@firebase/functions" "0.8.4"
     "@firebase/functions-compat" "0.2.4"
     "@firebase/installations" "0.5.12"


### PR DESCRIPTION
## Change Summary
Targets issue #63 

Created a reusable button component with some variants:

- Size: small, medium, large
- Intent: primary, secondary
- Fullwidth: `boolean`

Replaced all text label buttons with an equivalent `<Button />`

### Change Form

- [X] The pull request title has an issue number
- [X] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
Uses the `class-variance-authority` package to enable the attributes / types / variants. While the package is small, it should mostly be used on SSR or SSG pages.