### PR TITLE
I215 remember the values of last visits for each clients in the visit form

### DIFF
--- a/src/components/Visit/clientselector.tsx
+++ b/src/components/Visit/clientselector.tsx
@@ -14,6 +14,7 @@ interface ClientSelectorProps extends Omit<FormFieldProps, 'value'> {
       petNames: string
     }>
   >
+  handleChange(newValue: SingleValue<SelectOption>): void
 }
 
 const ClientSelector = (props: ClientSelectorProps) => {
@@ -29,11 +30,6 @@ const ClientSelector = (props: ClientSelectorProps) => {
       return client
     })
   }
-  const handleChange = (newValue: SingleValue<SelectOption>) => {
-    // fired when user selects an option or creates an option
-    if (newValue === null) return
-    props.setClient({ clientName: newValue.label, petNames: newValue.value })
-  }
 
   return (
     <div className={props.className}>
@@ -43,7 +39,7 @@ const ClientSelector = (props: ClientSelectorProps) => {
           {props.label}
         </label>
         <Select
-          onChange={handleChange}
+          onChange={props.handleChange}
           options={getClientList()}
           placeholder={props.placeholder}
           styles={customStyles}

--- a/src/components/Visit/formfield.tsx
+++ b/src/components/Visit/formfield.tsx
@@ -53,7 +53,6 @@ const inputSwitch = (props: FormFieldProps) => {
           required={props.isRequired}
           onChange={props.onChange}
         >
-          <option value=''>{props.placeholder}</option>
           {props.selectOptions?.map((o, i) => (
             <option key={i} value={o.value}>
               {o.label}

--- a/src/hooks/visits.ts
+++ b/src/hooks/visits.ts
@@ -7,6 +7,8 @@ import {
   doc,
   FirestoreError,
   getDocs,
+  orderBy,
+  query,
   setDoc
 } from 'firebase/firestore'
 
@@ -22,7 +24,8 @@ export const useVisits = () => {
     if (currentUser?.uid) {
       try {
         const visitsRef = collection(db, 'users', currentUser.uid, 'visits')
-        const visitsDocs = await getDocs(visitsRef)
+        const q = query(visitsRef, orderBy('startTime', 'desc'))
+        const visitsDocs = await getDocs(q)
         return visitsDocs.docs.map(
           (doc) => ({ ...doc.data(), docId: doc.id } as Visit)
         )

--- a/src/pages/visit/[id]/index.tsx
+++ b/src/pages/visit/[id]/index.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { Timestamp } from 'firebase/firestore'
+import { SingleValue } from 'react-select'
 
 import { withProtected } from '@/components/PrivateRoute'
 import Button from '@/components/UI/button'
@@ -11,7 +12,7 @@ import CommuteSelector from '@/components/Visit/commuteselector'
 import DurationSelector from '@/components/Visit/durationselector'
 import FormField from '@/components/Visit/formfield'
 import { useMutateVisits, useVisits } from '@/hooks/visits'
-import { Duration, Visit } from '@/types/types'
+import { Duration, SelectOption,Visit } from '@/types/types'
 import { formatTimestamp, visitSelectOptions } from '@/utils'
 
 const Set = () => {
@@ -110,6 +111,24 @@ const Set = () => {
     duration.minutes >= 0
   walkDist >= 0 && commuteDist >= 0 && commuteMethod
 
+  const handleClientChange = (newValue: SingleValue<SelectOption>) => {
+    // fired when user selects an option or creates an option
+    if (newValue === null) return
+    setClientPetNames({ clientName: newValue.label, petNames: newValue.value })
+
+    // no need to prefill if not new visit
+    if (!isNewVisit) return
+
+    // getting past visit for selected client to prefill
+    const pastVisit = visits?.find((visit) => visit.clientName === newValue.label)
+    if (pastVisit !== undefined) {
+      setDuration(pastVisit.duration)
+      setCommuteDist(pastVisit.commuteDist)
+      setCommuteMethod(pastVisit.commuteMethod)
+      setWalkDist(pastVisit.walkDist)
+    }
+  }
+
   return (
     <div className='space-4 z-50 flex h-full flex-col p-4'>
       {/* Exit Button */}
@@ -146,6 +165,7 @@ const Set = () => {
               label='Client Name:'
               isRequired={true}
               setClient={setClientPetNames}
+              handleChange={handleClientChange}
             />
             <FormField
               id='visitTypeInput'

--- a/src/pages/visit/[id]/index.tsx
+++ b/src/pages/visit/[id]/index.tsx
@@ -12,7 +12,7 @@ import CommuteSelector from '@/components/Visit/commuteselector'
 import DurationSelector from '@/components/Visit/durationselector'
 import FormField from '@/components/Visit/formfield'
 import { useMutateVisits, useVisits } from '@/hooks/visits'
-import { Duration, SelectOption,Visit } from '@/types/types'
+import { Duration, SelectOption, Visit } from '@/types/types'
 import { formatTimestamp, visitSelectOptions } from '@/utils'
 
 const Set = () => {
@@ -25,7 +25,9 @@ const Set = () => {
     queryId === undefined || Array.isArray(queryId) ? null : queryId
   const visit = visits?.find((visit) => queryId && visit.docId === visitId)
 
-  const [visitType, setVisitType] = useState<string>('')
+  const [visitType, setVisitType] = useState<string>(
+    visitSelectOptions[0].value
+  )
   const [clientPetNames, setClientPetNames] = useState<{
     clientName: string
     petNames: string
@@ -120,7 +122,9 @@ const Set = () => {
     if (!isNewVisit) return
 
     // getting past visit for selected client to prefill
-    const pastVisit = visits?.find((visit) => visit.clientName === newValue.label)
+    const pastVisit = visits?.find(
+      (visit) => visit.clientName === newValue.label
+    )
     if (pastVisit !== undefined) {
       setDuration(pastVisit.duration)
       setCommuteDist(pastVisit.commuteDist)
@@ -170,7 +174,6 @@ const Set = () => {
             <FormField
               id='visitTypeInput'
               type='select'
-              placeholder='Select...'
               value={visitType}
               label='Visit Type:'
               selectOptions={visitSelectOptions}

--- a/src/pages/visit/[id]/index.tsx
+++ b/src/pages/visit/[id]/index.tsx
@@ -114,14 +114,12 @@ const Set = () => {
   walkDist >= 0 && commuteDist >= 0 && commuteMethod
 
   const handleClientChange = (newValue: SingleValue<SelectOption>) => {
-    // fired when user selects an option or creates an option
     if (newValue === null) return
+
     setClientPetNames({ clientName: newValue.label, petNames: newValue.value })
 
-    // no need to prefill if not new visit
     if (!isNewVisit) return
 
-    // getting past visit for selected client to prefill
     const pastVisit = visits?.find(
       (visit) => visit.clientName === newValue.label
     )

--- a/src/pages/visit/[id]/index.tsx
+++ b/src/pages/visit/[id]/index.tsx
@@ -135,16 +135,6 @@ const Set = () => {
         <form onSubmit={handleSubmit}>
           {/* could rewrite to use awful react-select to make chevron icon consistent */}
           <div className='grid grid-cols-2 gap-4'>
-            <FormField
-              id='visitTypeInput'
-              type='select'
-              placeholder='Select...'
-              value={visitType}
-              label='Visit Type:'
-              selectOptions={visitSelectOptions}
-              isRequired={true}
-              onChange={(event) => setVisitType(event.target.value)}
-            />
             <ClientSelector
               id='clientNameInput'
               type='text'
@@ -157,7 +147,16 @@ const Set = () => {
               isRequired={true}
               setClient={setClientPetNames}
             />
-
+            <FormField
+              id='visitTypeInput'
+              type='select'
+              placeholder='Select...'
+              value={visitType}
+              label='Visit Type:'
+              selectOptions={visitSelectOptions}
+              isRequired={true}
+              onChange={(event) => setVisitType(event.target.value)}
+            />
             <FormField
               id='commuteDistInput'
               type='number'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -38,6 +38,6 @@ export const humanizeTimestamp = (timestamp?: Timestamp) => {
 }
 
 export const visitSelectOptions: SelectOption[] = [
-  { label: 'Vet', value: 'Vet' },
-  { label: 'Walk', value: 'Walk' }
+  { label: 'Walk', value: 'Walk' },
+  { label: 'Vet', value: 'Vet' }
 ]


### PR DESCRIPTION
## Change Summary
**[Briefly summarise the changes that you made. Just high-level stuff]**
- Visits are now ordered by latest start time
- Default visit type is `walk`
- When a client name is selected, all fields are prefilled with the most recent visit for the selected client (excluding `visitType`, `startTime` and `notes`

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [X] The pull request title has an issue number
- [X] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**
- Should visits instead be sorted by the last updated time of the visit?

# Related Issue

- Resolve #215