### PR TITLE
I255 add a see more button to notes in visits

### DIFF
--- a/src/components/Visit/readvisitinstance.tsx
+++ b/src/components/Visit/readvisitinstance.tsx
@@ -65,7 +65,16 @@ const VisitInfo = ({
         </div>
         <div>
           <div className='font-semibold'>Notes:</div>
-          <p className='my-1 line-clamp-6'>{notes}</p>
+          <p className='my-1 whitespace-pre-wrap line-clamp-6'>{notes}</p>
+          {notes.length > 100 && (
+            <Button
+              size='small'
+              intent='secondary'
+              onClick={() => router.push(`/visit/${docId}/notes`)}
+            >
+              See More
+            </Button>
+          )}
         </div>
       </div>
       <div className='flex h-full items-center justify-around py-2'>

--- a/src/pages/visit/[id]/notes.tsx
+++ b/src/pages/visit/[id]/notes.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import { withProtected } from '@/components/PrivateRoute'
 import Modal from '@/components/UI/modal'
 import { useVisits } from '@/hooks/visits'
+import { humanizeTimestamp } from '@/utils'
 
 const Notes = () => {
   const { data: visits } = useVisits()
@@ -16,7 +17,13 @@ const Notes = () => {
   return (
     <Modal title='Notes' backLink='/visit'>
       {visit ? (
-        <p className='whitespace-pre-wrap leading-7'>{visit.notes}</p>
+        <div>
+          <div className='font-bold'>
+            <p className='text-primary'>{humanizeTimestamp(visit.startTime)}</p>
+            <p>{visit.clientName}</p>
+          </div>
+          <p className='whitespace-pre-wrap text-sm leading-6'>{visit.notes}</p>
+        </div>
       ) : (
         'Error: no notes found'
       )}

--- a/src/pages/visit/[id]/notes.tsx
+++ b/src/pages/visit/[id]/notes.tsx
@@ -1,0 +1,27 @@
+import { useRouter } from 'next/router'
+
+import { withProtected } from '@/components/PrivateRoute'
+import Modal from '@/components/UI/modal'
+import { useVisits } from '@/hooks/visits'
+
+const Notes = () => {
+  const { data: visits } = useVisits()
+  const router = useRouter()
+
+  const { id: queryId } = router.query
+  const visitId =
+    queryId === undefined || Array.isArray(queryId) ? null : queryId
+  const visit = visits?.find((visit) => queryId && visit.docId === visitId)
+
+  return (
+    <Modal title='Notes' backLink='/visit'>
+      {visit ? (
+        <p className='whitespace-pre-wrap leading-7'>{visit.notes}</p>
+      ) : (
+        'Error: no notes found'
+      )}
+    </Modal>
+  )
+}
+
+export default withProtected(Notes)


### PR DESCRIPTION
## Change Summary
Added a see more button that opens a notes page, but only shows up when the notes are longer than 100 characters.

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**

# Related Issue

- Resolve #255