### PR TITLE
I268 make admin stats page mobile friendly

### DIFF
--- a/src/components/Admin/statsbreakdown.tsx
+++ b/src/components/Admin/statsbreakdown.tsx
@@ -22,48 +22,50 @@ const StatsBreakdown = ({ days = 7 }: StatsBreakdownProps) => {
   )
 
   return (
-    <Card title={`${days} Day Breakdown (Average per Volunteer)`}>
-      {isLoading || data === undefined ? (
-        <Spinner style='h-10 w-10 fill-primary-dark text-gray-200 m-4' />
-      ) : (
-        <table className='w-full'>
-          <tbody>
-            <tr>
-              <td>
-                <Statistics
-                  title='Visits'
-                  data={`${data.avgVisitCount}`}
-                  tooltip={`Total: ${data.totalVisitCount}`}
-                />
-              </td>
-              <td>
-                <Statistics
-                  title='Walk Duration: '
-                  data={`${data.avgWalkTime} min`}
-                  tooltip={`Total: ${data.totalWalkTime} min`}
-                />
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <Statistics
-                  title='Walk Distance'
-                  data={`${data.avgWalkDistance} km`}
-                  tooltip={`Total: ${data.totalWalkDistance} km`}
-                />
-              </td>
-              <td>
-                <Statistics
-                  title='Commute Distance'
-                  data={`${data.avgCommuteDistance} km`}
-                  tooltip={`Total: ${data.totalCommuteDistance} km`}
-                />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      )}
-    </Card>
+    <div className='px-4'>
+      <Card title={`${days} Day Breakdown (Average per Volunteer)`}>
+        {isLoading || data === undefined ? (
+          <Spinner style='h-10 w-10 fill-primary-dark text-gray-200 m-4' />
+        ) : (
+          <table className='w-full'>
+            <tbody>
+              <tr>
+                <td>
+                  <Statistics
+                    title='Visits'
+                    data={`${data.avgVisitCount}`}
+                    tooltip={`Total: ${data.totalVisitCount}`}
+                  />
+                </td>
+                <td>
+                  <Statistics
+                    title='Walk Duration: '
+                    data={`${data.avgWalkTime} min`}
+                    tooltip={`Total: ${data.totalWalkTime} min`}
+                  />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <Statistics
+                    title='Walk Distance'
+                    data={`${data.avgWalkDistance} km`}
+                    tooltip={`Total: ${data.totalWalkDistance} km`}
+                  />
+                </td>
+                <td>
+                  <Statistics
+                    title='Commute Distance'
+                    data={`${data.avgCommuteDistance} km`}
+                    tooltip={`Total: ${data.totalCommuteDistance} km`}
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </div>
   )
 }
 

--- a/src/components/Admin/volunteerstatstable.tsx
+++ b/src/components/Admin/volunteerstatstable.tsx
@@ -18,12 +18,7 @@ interface FormValues {
 const YEAR_IN_MS = 31556952000
 const queryKey = 'mainVolunteerStatsTable'
 
-const headers = [
-  'Number of Visits',
-  'Walk Duration (mins)',
-  'Walk Distance (kms)',
-  'Commute Distance (kms)'
-]
+const headers = ['Visit Count', 'Walk (mins)', 'Walk (kms)', 'Commute (kms)']
 
 const VolunteerStatsTable = () => {
   const now = Date.now()
@@ -74,7 +69,7 @@ const VolunteerStatsTable = () => {
               }
             }, [from, to])}
           >
-            <div className='flex flex-row justify-center gap-4 p-2 text-left'>
+            <div className='flex flex-col justify-center gap-4 p-2 text-left'>
               <TextField
                 className='col-span-2 m-2'
                 label='From:'
@@ -142,29 +137,32 @@ const VolunteerStatsTable = () => {
               <Spinner style='h-10 w-10 fill-primary-dark text-gray-200 m-4' />
             </div>
           ) : (
-            <div className='w-full text-center'>
-              <table className='border-4 border-primary-dark'>
+            <div className='m-auto flex flex-col items-center justify-center'>
+              <div className='mb-2 p-2 text-lg'>
+                Total Number of Volunteers: {volunteerStats?.volunteerCount}
+              </div>
+              <table className='border-2 border-primary-dark'>
                 <thead>
                   <tr>
                     <th></th>
-                    <th className='border-4 border-primary-dark p-6 text-xl font-normal'>
+                    <th className='text-md border-2 border-primary-dark p-2 font-normal md:text-lg lg:text-xl'>
                       Total
                     </th>
-                    <th className='border-4 border-primary-dark p-6 text-xl font-normal'>
-                      Average (per volunteer)
+                    <th className='text-md border-2 border-primary-dark p-2 font-normal md:text-lg lg:text-xl'>
+                      Avg (per volunteer)
                     </th>
                   </tr>
                 </thead>
                 <tbody>
                   {headers.map((header, i) => (
                     <tr key={i}>
-                      <th className='border-4 border-primary-dark p-6 text-xl font-normal'>
+                      <th className='text-md border-2 border-primary-dark p-2 font-normal md:text-lg lg:text-xl'>
                         {header}
                       </th>
-                      <td className='border-4 border-primary-dark p-10 text-3xl text-primary-dark'>
+                      <td className='border-2 border-primary-dark p-2 text-lg text-primary-dark md:text-xl lg:text-2xl'>
                         {totalStats[i]}
                       </td>
-                      <td className='border-4 border-primary-dark p-10 text-3xl text-primary-dark'>
+                      <td className='border-2 border-primary-dark p-2 text-lg text-primary-dark md:text-xl lg:text-2xl'>
                         {avgStats[i]}
                       </td>
                     </tr>
@@ -175,13 +173,6 @@ const VolunteerStatsTable = () => {
           )}
         </div>
       </Card>
-
-      <div className='mt-4 flex items-baseline gap-2 p-2 text-3xl'>
-        <div>Total Number of Volunteers: </div>
-        <div className='text-primary-dark'>
-          {volunteerStats?.volunteerCount}
-        </div>
-      </div>
     </div>
   )
 }

--- a/src/components/Admin/volunteerstatstable.tsx
+++ b/src/components/Admin/volunteerstatstable.tsx
@@ -18,7 +18,12 @@ interface FormValues {
 const YEAR_IN_MS = 31556952000
 const queryKey = 'mainVolunteerStatsTable'
 
-const headers = ['Visit Count', 'Walk (mins)', 'Walk (kms)', 'Commute (kms)']
+const headers = [
+  'Visit Count',
+  'Walk Duration (mins)',
+  'Walk Distance (kms)',
+  'Commute Distance (kms)'
+]
 
 const VolunteerStatsTable = () => {
   const now = Date.now()
@@ -149,7 +154,7 @@ const VolunteerStatsTable = () => {
                       Total
                     </th>
                     <th className='text-md border-2 border-primary-dark p-2 font-normal md:text-lg lg:text-xl'>
-                      Avg (per volunteer)
+                      Average (per volunteer)
                     </th>
                   </tr>
                 </thead>

--- a/src/components/Admin/volunteerstatstable.tsx
+++ b/src/components/Admin/volunteerstatstable.tsx
@@ -146,44 +146,29 @@ const VolunteerStatsTable = () => {
               <table className='border-4 border-primary-dark'>
                 <thead>
                   <tr>
-                    <th />
-                    {headers.map((header) => (
-                      <th
-                        key={header}
-                        className='border-4 border-primary-dark p-6 text-xl font-normal'
-                      >
-                        {header}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
+                    <th></th>
                     <th className='border-4 border-primary-dark p-6 text-xl font-normal'>
                       Total
                     </th>
-                    {totalStats.map((stat, i) => (
-                      <td
-                        key={`${i}:${stat}`}
-                        className='border-4 border-primary-dark p-10 text-3xl text-primary-dark'
-                      >
-                        {stat}
-                      </td>
-                    ))}
-                  </tr>
-                  <tr>
                     <th className='border-4 border-primary-dark p-6 text-xl font-normal'>
                       Average (per volunteer)
                     </th>
-                    {avgStats.map((stat) => (
-                      <td
-                        key={stat}
-                        className='border-4 border-primary-dark p-10 text-3xl text-primary-dark'
-                      >
-                        {stat}
-                      </td>
-                    ))}
                   </tr>
+                </thead>
+                <tbody>
+                  {headers.map((header, i) => (
+                    <tr key={i}>
+                      <th className='border-4 border-primary-dark p-6 text-xl font-normal'>
+                        {header}
+                      </th>
+                      <td className='border-4 border-primary-dark p-10 text-3xl text-primary-dark'>
+                        {totalStats[i]}
+                      </td>
+                      <td className='border-4 border-primary-dark p-10 text-3xl text-primary-dark'>
+                        {avgStats[i]}
+                      </td>
+                    </tr>
+                  ))}
                 </tbody>
               </table>
             </div>

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -33,55 +33,66 @@ const Admin = () => {
   return (
     <>
       <Header pageTitle='Admin' />
-      <h1 className='m-3 flex-1 text-center text-2xl'>Admin</h1>
-      <p>User: {currentUser?.displayName}</p>
-      <p>Email: {currentUser?.email}</p>
-      <p>Admin status: {isAdmin.toString()}</p>
-      <p>User role firestore document: {JSON.stringify(userDoc)}</p>
-      <Button
-        size='medium'
-        intent='secondary'
-        type='button'
-        onClick={async () => refreshUserToken()}
-      >
-        Refresh Token
-      </Button>
+      <div className='main-style'>
+        <div className='flex h-full w-screen flex-col justify-center text-center'>
+          <div className='mb-4'>
+            <h1 className='flex-1 text-2xl'>Admin</h1>
+          </div>
+          <div>
+            <p>User: {currentUser?.displayName}</p>
+            <p>Email: {currentUser?.email}</p>
+            <p>Admin status: {isAdmin.toString()}</p>
+            <p>User role firestore document: {JSON.stringify(userDoc)}</p>
+            <Button
+              size='medium'
+              intent='secondary'
+              type='button'
+              onClick={async () => refreshUserToken()}
+            >
+              Refresh Token
+            </Button>
 
-      <div className='m-2'>
-        <Button
-          size='medium'
-          intent='primary'
-          type='button'
-          onClick={() => Router.push('/admin/incidents')}
-        >
-          View Incidents
-        </Button>
-        <Button
-          size='medium'
-          intent='primary'
-          type='button'
-          onClick={() => Router.push('/admin/concerns')}
-        >
-          View Concerns
-        </Button>
-        <Button
-          size='medium'
-          intent='primary'
-          type='button'
-          onClick={() => Router.push('/admin/roles')}
-        >
-          View Roles
-        </Button>
-        <Button
-          size='medium'
-          intent='primary'
-          type='button'
-          onClick={() => Router.push('/admin/stats')}
-        >
-          View Stats
-        </Button>
+            <div className='m-2'>
+              <Button
+                size='medium'
+                intent='primary'
+                type='button'
+                onClick={() => Router.push('/admin/incidents')}
+                className='m-1'
+              >
+                View Incidents
+              </Button>
+              <Button
+                size='medium'
+                intent='primary'
+                type='button'
+                onClick={() => Router.push('/admin/concerns')}
+                className='m-1'
+              >
+                View Concerns
+              </Button>
+              <Button
+                size='medium'
+                intent='primary'
+                type='button'
+                onClick={() => Router.push('/admin/roles')}
+                className='m-1'
+              >
+                View Roles
+              </Button>
+              <Button
+                size='medium'
+                intent='primary'
+                type='button'
+                onClick={() => Router.push('/admin/stats')}
+                className='m-1'
+              >
+                View Stats
+              </Button>
+            </div>
+          </div>
+        </div>
       </div>
-
       <NavBar />
     </>
   )

--- a/src/pages/admin/stats.tsx
+++ b/src/pages/admin/stats.tsx
@@ -11,20 +11,18 @@ import { NextPageWithLayout } from '@/pages/_app'
 const Stats: NextPageWithLayout = () => {
   return (
     <div className='main-style container m-4 mx-auto flex flex-col gap-4'>
-      <div>
+      <div className='flex-1'>
         <Button
           size='medium'
-          intent='primary'
           type='button'
-          className='m-3'
           onClick={() => Router.push('/admin')}
         >
           Back
         </Button>
+        <h1 className='m-3 flex-1 text-center text-3xl font-bold text-primary-dark'>
+          Admin Summary Dashboard
+        </h1>
       </div>
-      <h1 className='mx-auto text-center text-4xl font-bold text-primary-dark'>
-        Admin Summary Dashboard
-      </h1>
       <StatsBreakdown />
       <div className='mb-20'>
         <VolunteerStatsTable />


### PR DESCRIPTION
## Change Summary
Adjusted the styling of the admin/index and stats pages to be mobile friendly, and changed the table layout of the statistics.

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**

# Related Issue

- Resolve #268